### PR TITLE
GS-110: Rename prospect pivot table 'total amount' field to 'total co…

### DIFF
--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -161,6 +161,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
       foreach ($includeFields['contribution'] as $fieldKey) {
         $fields['contribution'][$fieldKey] = $contributionFields[$fieldKey];
       }
+      $fields['contribution']['total_amount']['title'] = ts('Total Contribution Amount');
       $fields['contribution']['contribution_status'] = ts('Contribution Status');
 
       // Include Pledge fields.


### PR DESCRIPTION
The 'total amount' field in prospect pivot table in pivot reports extension should be renamed to 'total contribution amount'

before 
<img width="772" alt="4043791599-2018-01-17 16_07_43-prospect pivot report _ d4727_4" src="https://user-images.githubusercontent.com/6275540/35231273-4701cb40-ff90-11e7-8243-b8e4ce115b71.png">



after
<img width="795" alt="1013031244-2018-01-17 16_06_50-prospect pivot report _ d4727_4" src="https://user-images.githubusercontent.com/6275540/35231272-46d5a7fe-ff90-11e7-85c4-4bb7c9c51e98.png">

