### PR TITLE
WIP-PCHR-3431: Reports Milestone One POC.

### DIFF
--- a/CRM/PivotCache/GroupContact.php
+++ b/CRM/PivotCache/GroupContact.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @inheritdoc
+ */
+class CRM_PivotCache_GroupContact extends CRM_PivotCache_AbstractGroup {
+
+  public function __construct($name = NULL, $source = NULL) {
+    parent::__construct('Contact', $source);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
+    if (!empty($params['keyvalue_from'])) {
+      $whereStartDate = CRM_Core_DAO::createSQLFilter(
+        'path',
+        array(
+          '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page),
+        ),
+        'String'
+      );
+
+      $queryObject->whereAdd($whereStartDate);
+    }
+
+    if (!empty($params['keyvalue_to'])) {
+      $whereEndDate = CRM_Core_DAO::createSQLFilter(
+        'path',
+        array(
+          '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999),
+        ),
+        'String'
+      );
+
+      $queryObject->whereAdd($whereEndDate);
+    }
+  }
+}

--- a/CRM/PivotData/DataContact.php
+++ b/CRM/PivotData/DataContact.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Provides a functionality to prepare People data for Pivot Table.
+ */
+class CRM_PivotData_DataContact extends CRM_PivotData_AbstractData {
+
+  /**
+   * CRM_PivotData_DataContact constructor.
+   */
+  public function __construct() {
+    parent::__construct('Contact');
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getEntityApiParams(array $inputParams) {
+    $jobContractFields = $this->getEntityFields('jobcontract');
+    $idKey = array_search('id', $jobContractFields);
+    //adding the ID as part of the return field gives unpredictable results with mismatched jobroles
+    //Id will still get returned nonetheless
+    unset($jobContractFields[$idKey]);
+    $params = [
+      'sequential' => 1,
+      'return' => $this->getEntityFields('contact'),
+//      'contact_id' => ['IN' => [204, 206, 113, 208, 151, 152, 153, 154, 155]],
+      'contact_type' => 'Individual',
+      'is_deleted' => 0,
+      'api.HRJobContract.get' => [
+        'sequential' => 1,
+        'contact_id' => "\$value.contact_id",
+        'return' => $jobContractFields,
+        'api.HrJobRoles.get' => ['sequential' => 1, 'job_contract_id' => "\$value.id", 'return' => $this->getEntityFields('jobroles')],
+      ],
+      'options' => [
+        'limit' => self::ROWS_API_LIMIT,
+      ],
+    ];
+
+    return $params;
+  }
+
+  /**
+   * Returns an array containing Entity fields.
+   *
+   * @return array
+   */
+  protected function getEntityFields($entityName) {
+    $result = [];
+    $fields = array_keys($this->getFields());
+
+    foreach ($fields as $field) {
+      $fieldParts = explode('.', $field);
+      if ($fieldParts[0] === $entityName) {
+        $result[] = $fieldParts[1];
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function formatResult($data, $dataKey = null, $level = 0) {
+    $result = [];
+    $resultRow = [];
+
+    foreach ($data as $key => $dataRow) {
+      $contactValues = $this->getRowValues($dataRow, 'contact');
+      $contractValues = $dataRow['api.HRJobContract.get']['values'];
+      foreach($contractValues as $contract) {
+        $contractRow = $this->getRowValues($contract, 'jobcontract');
+        $roleRow = $this->getRowValues(array_shift($contract['api.HrJobRoles.get']['values']), 'jobroles');
+        $row = array_merge($contactValues, $contractRow, $roleRow);
+        $row = $this->formatRow($key, $row);
+        $resultRow[] = $row;
+      }
+
+      if(empty($resultRow)) {
+        $resultRow[] = $this->formatRow($key, $contactValues);
+      }
+
+      $headers = array_merge($this->emptyRow, $this->additionalHeaderFields);
+      $finalRow = [];
+      foreach($resultRow as $row) {
+        foreach ($headers as $key => $header) {
+          if (isset($row[$key])) {
+            $finalRow[$key] = $row[$key];
+          }
+          else {
+            $finalRow[$key] = '';
+          }
+
+        }
+        $result[] = $finalRow;
+      }
+
+      $resultRow = [];
+    }
+
+    return $result;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getEntityIndex(array $row) {
+    return substr($row['Contract Start Date'], 0, 10);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getFields() {
+    if (empty($this->fields)) {
+      $fields = [];
+      $keys = [];
+      $groups = ['contact', 'jobcontract', 'jobroles'];
+      $result = [];
+
+      // Now get Custom Fields for Contact entity.
+      $customFieldsResult = CRM_Core_DAO::executeQuery(
+        'SELECT g.id AS group_id, f.id AS id, f.label AS label, f.data_type AS data_type, ' .
+        'f.html_type AS html_type, f.date_format AS date_format, og.name AS option_group_name ' .
+        'FROM `civicrm_custom_group` g ' .
+        'LEFT JOIN `civicrm_custom_field` f ON f.custom_group_id = g.id ' .
+        'LEFT JOIN `civicrm_option_group` og ON og.id = f.option_group_id ' .
+        'WHERE g.extends IN(\'Individual\',\'Contact\') AND g.is_active = 1 AND f.is_active = 1 '
+      );
+
+      while ($customFieldsResult->fetch()) {
+        $customField = new CRM_Core_BAO_CustomField();
+        $customField->id = $customFieldsResult->id;
+        $customField->find(true);
+
+        $fields['contact']['custom_' . $customFieldsResult->id] = array(
+          'name' => 'custom_' . $customFieldsResult->id,
+          'title' => $customFieldsResult->label,
+          'pseudoconstant' => array(
+            'optionGroupName' => $customFieldsResult->option_group_name,
+          ),
+          'customField' => (array)$customField,
+        );
+      }
+      //Add contact fields
+      $fields['contact']['display_name'] = ['name' => 'display_name', 'title' => 'Display Name'];
+      $fields['contact']['contact_type'] = ['name' => 'contact_type', 'title' => 'Contact Type'];
+      $fields['contact']['contact_id'] = ['name' => 'contact_id', 'title' => 'Contact ID'];
+      $fields['contact']['birth_date'] = ['name' => 'contact_id', 'title' => 'Birth Date'];
+
+      $fields['jobcontract']['id'] = ['name' => 'id', 'title' => ts('Contract ID')];
+      $fields['jobcontract']['position'] = ['name' => 'position', 'title' => ts('Contract Position')];
+      $fields['jobcontract']['title'] = ['name' => 'title', 'title' => ts('Contract Title')];
+      $fields['jobcontract']['contract_type'] = ['name' => 'contract_type', 'title' => ts('Contract Type')];
+      $fields['jobcontract']['period_start_date'] = ['name' => 'period_start_date', 'title' => ts('Contract Start Date')];
+      $fields['jobcontract']['period_end_date'] = ['name' => 'period_end_date', 'title' => ts('Contract End Date')];
+      $fields['jobcontract']['is_current'] = ['name' => 'is_current', 'title' => ts('Current Contract')];
+
+      $fields['jobroles']['id'] = ['name' => 'id', 'title' => ts('Role ID')];
+      $fields['jobroles']['start_date'] = ['name' => 'start_date', 'title' => ts('Role Start Date')];
+      $fields['jobroles']['end_date'] = ['name' => 'end_date', 'title' => ts('Role End Date')];
+      $fields['jobroles']['title'] = ['name' => 'title', 'title' => ts('Role Title')];
+      $fields['jobroles']['description'] = ['name' => 'description', 'title' => ts('Role Description')];
+      $fields['jobroles']['location'] = ['name' => 'location', 'title' => ts('Role Location')];
+      $fields['jobroles']['department'] = ['name' => 'department', 'title' => ts('Role Department')];
+      $fields['jobroles']['functional_area'] = ['name' => 'functional_area', 'title' => ts('Role Functional Area')];
+      $fields['jobroles']['hours'] = ['name' => 'hours', 'title' => ts('Role Hours')];
+      $fields['jobroles']['role_hours_unit'] = ['name' => 'role_hours_unit', 'title' => ts('Role Hours Unit')];
+      $fields['jobroles']['level_type'] = ['name' => 'level_type', 'title' => ts('Role Level Type')];
+      $fields['jobroles']['organization'] = ['name' => 'organization', 'title' => ts('Role Organization')];
+
+
+      foreach ($groups as $group) {
+        foreach ($fields[$group] as $key => $value) {
+          if (!empty($value['name']) && !empty($keys[$group][$value['name']])) {
+            $key = $value['name'];
+          }
+          $result[$group . '.' . $key] = $value;
+
+          if (is_array($value)) {
+            $result[$group . '.' . $key]['optionValues'] = $this->getOptionValues($value);
+          }
+        }
+      }
+
+      $this->fields = $result;
+    }
+
+    return $this->fields;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(array $params = []) {
+    $apiParams = [
+      'is_deleted' => 0,
+      'contact_type' => 'Individual',
+//      'id' => ['IN' => [204, 206, 113, 208, 151, 152, 153, 154, 155]],
+    ];
+
+    return civicrm_api3('Contact', 'getcount', $apiParams);
+  }
+
+}

--- a/CRM/PivotReport/Entity.php
+++ b/CRM/PivotReport/Entity.php
@@ -16,6 +16,7 @@ class CRM_PivotReport_Entity {
       ),
     ),
     'Membership' => array(),
+    'Contact' => array(),
     'Prospect' => array(
       'extensions' => array(
         'uk.co.compucorp.civicrm.prospect',

--- a/templates/CRM/PivotReport/Page/ContactReport.tpl
+++ b/templates/CRM/PivotReport/Page/ContactReport.tpl
@@ -1,0 +1,61 @@
+<div id="pivot-report-filters" class="hidden">
+    <form>
+        <fieldset>
+            <legend>Working Dataset Filter</legend>
+            <p>
+                The total number of items exceeds 1000. Only last 30 days loaded.
+                Use this form to change the date range for which data needs to be
+                visualized.
+            </p>
+            <label for="keyvalue_from">Load Contacts From:</label>
+            <input type="text" name="keyvalue_from" value="">
+            <label for="keyvalue_to">To:</label>
+            <input type="text" name="keyvalue_to" value="">
+            <input class="apply-filters-button" type="button" value="Apply filters">
+            <input class="load-all-data-button hidden" type="button" value="Load all data">
+        </fieldset>
+    </form>
+</div>
+
+{literal}
+<script type="text/javascript">
+    CRM.$(function ($) {
+      new CRM.PivotReport.PivotTable({
+        'entityName': 'Contact',
+        'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
+      });
+    });
+</script>
+{/literal}
+
+{literal}
+<script type="text/javascript">
+    CRM.$(function ($) {
+        new CRM.PivotReport.PivotTable({
+            'entityName': 'Contact',
+            'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
+            'filter': true,
+            'filterField': 'Contract Start Date',
+            'initialLoad': {
+                'limit': 1000,
+                'message': 'There are more than 1000 items, getting only items from last 30 days.',
+                'getFilter': function() {
+                    var startDateFilterValue = new Date();
+                    var endDateFilterValue = new Date();
+                    startDateFilterValue.setDate(startDateFilterValue.getDate() - 30);
+
+                    return new CRM.PivotReport.Filter(startDateFilterValue.toISOString().substring(0, 10), endDateFilterValue.toISOString().substring(0, 10));
+                }
+            },
+            'initFilterForm': function(keyValueFromField, keyValueToField) {
+                keyValueFromField.crmDatepicker({
+                    time: false
+                });
+                keyValueToField.crmDatepicker({
+                    time: false
+                });
+            },
+        });
+    });
+</script>
+{/literal}

--- a/xml/Menu/pivotreport.xml
+++ b/xml/Menu/pivotreport.xml
@@ -35,4 +35,10 @@
     <page_arguments>entity=Prospect</page_arguments>
     <access_arguments>access CiviCRM pivot table reports</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contact-report</path>
+    <page_callback>CRM_PivotReport_Page_PivotReport</page_callback>
+    <page_arguments>entity=Contact</page_arguments>
+    <access_arguments>access CiviCRM pivot table reports</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
This is not a proper PR per say but a proof of concept to demonstrate how to use the Pivot report extension to display the People reports in CiviHR.

- After studying implementations for the Activity and Membership reports I was able to get the People report(with CSV export) working with: 
Contacts (with all custom fields)
Contracts 
Roles.
- The Date filter is based on the Job contract start date,  there is a Current Contact column in the report that states whether the contract is the one being used by the contact or not. I am still investigating how to filter by current contract of a contact mainly because the extension only allows the report to be filterable by the index key which is usually a date field,(still checking how to see if two index keys can be combined), 

![contact pivot report _ staging17 2018-03-16 19-23-40](https://user-images.githubusercontent.com/6951813/37537996-9ba0cdac-294f-11e8-9e84-44ebe415792d.png)

![contact pivot report _ staging17 2018-03-16 19-28-01](https://user-images.githubusercontent.com/6951813/37538215-33e8b7d2-2950-11e8-8737-3594de77cf65.png)




**Limitations**
- The Pivot reports extension works by adding support for Entities and the way it is presently it can support any Entity by extending some required classes and creating template file to display the report. However this has some limitations. 
- The classes for the report must be named after the entity name. For example the main entity of the people report is the Contact entity, I could not name my classes e.g `CRM_PivotData_DataPeople` for the Entity data class but I had to name it `CRM_PivotData_DataContact`. This has some limitations, for instance it means I can't have two reports of which Contact is the main entity because there would be a name clash.
- The Data for the Entity will always expect to get data from `civicrm_api3($EntityName, 'get', $apiParams);` [See](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/a5ea87257dd0bc64c6e394761eb1f7733752cf2b/CRM/PivotData/AbstractData.php#L365) , This means that the data will always be provided via the get method of the API and additional data has to be gotten by chaining API calls together as seen here: [See](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/ca26eabc7191425e3fd8cbfe97663d39a18c28ca/CRM/PivotData/DataMembership.php#L23) . This will make it difficult to get data for Entities like Leave Request that the get method can not provide all the data we need even with chaining to other API calls due to the fact that complex calculations need to be done before the data set is returned. For the People report however I was able to get it working as the data can be gotten from the API directly and by chaining API calls together.  
Chaining API calls has its own overhead considering the fact that the API's would be called multiple times.
- The extension provides a way to add menu items for reports dynamically by first of all checking for the supported entities and then adding the menu items for the supported entities. The Prospect report for instance has a dependency that the 'uk.co.compucorp.civicrm.prospect' must be installed before the report Link can be added to the menu. [See](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/ca26eabc7191425e3fd8cbfe97663d39a18c28ca/CRM/PivotReport/Entity.php#L21). The links are added via an upgrader [Here](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/2db2661c4f6c68daa700090591b4f1c09ab5f311/CRM/PivotReport/Upgrader.php#L133). The impact of this is that when the dependency of a supported entity is not met after the pivot extension has been enabled, the report menu for that Entity still remains on the Pivot report menu.
- The Pivot Report menu's are added under the core Civicrm Reports menu. The Reports menu is hidden for CiviHR [here](https://github.com/civicrm/civihr/blob/94deaa003f590b7a3e07e0027606ae45c7da9660/uk.co.compucorp.civicrm.hrcore/hrcore.php#L388), I had to manually comment this out to get the Menu to show on my Local.
- For the People report in this PR, when the date filters are used, the total count for the contracts with start period dates between the dates passed is gotten from [Here](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/a6c5f159cb71ef1246d3cbcd2151ebe7b597d200/js/PivotReport.PivotTable.js#L516), In reality what is needed is actually the number of contracts with period start dates between those dates but because Contact is the main entity, and there is no way to filter based on any chained entity, the returned total is a false representation, although this is only used to show the progress bar of the data load.
- There is no way to format a report field e.g similar to view handlers, For example on the CiviHR people report, the Contact birth_date 
field is formatted to display the age group of the contact.

**Caching**
- The Pivot report has to fetch data for an entity first and store it in the `civicrm_pivotreportcache` table, the cache can be built manually or automatically via a cron job.
The data are are stored as Json in the data column of the table and as such is not searchable or filterable.

**Date Filters**
- The report cannot be filtered by any of the report fields except the index key which is usually a date field, set for membership report  [here](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/ca26eabc7191425e3fd8cbfe97663d39a18c28ca/CRM/PivotData/DataMembership.php#L76): , This allows data on the same date to be grouped together and then can be searched using the date filter on the UI. 
The date filter on the UI only shows up when the data to be loaded is greater than the[ initial load limit](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/d58bddcc0ee49ef9da41e9db0eaa1118c426d021/templates/CRM/PivotReport/Page/ActivityReport.tpl#L29), only then does the [filter appear](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/d58bddcc0ee49ef9da41e9db0eaa1118c426d021/templates/CRM/PivotReport/Page/ActivityReport.tpl#L29) and then data can be filtered by the date on the chosen index field for the entity.

**Recommendations**
- Rather than name a report and subsequently the class names after the Entity, Let the Report have a Unique name that define what it does e.g instead of `CRM_PivotData_DataContact` we can have `CRM_PivotData_DataPeople`. The report name `People` will be passed in the regular functions that previously expected the Entity names. The implication is that rather than the Data classes relying on the  `civicrm_api3($EntityName, 'get', $apiParams);` to get the reports data, Each report class will have its own `getMethod`, exposed via the Pivot APi that will allow each report class to return data via any way it choses, either via API calls or via SQL queries.
whatever method used must still support an offset and limit which is what the current API  method leverages on. This way there won't be any main entity for a report and an Entity can be used across many reports to fetch information.
Also each Report class will have a `getCount` method that will be used everywhere and will accept filter parameters and return results based on those filters. (See the last note on limitations section).  This change will be done in such a way as not to affect existing reports as the Entity name will be assumed to be the reports name.
- Rather than supported Entities, it will be supported Reports and each Report can have its dependencies for it to be counted as supported such as an extension being enabled or a component being present e.t.c. The Reports menu will be added dynamically via `hook_civicrm_navigationMenu`, In this way, if a report is no longer valid due to a non existent dependency, its menu will not be shown on the Pivot reports menu links.
- Allow handlers to be added to a report field which transforms the data to the specified format before it is being cached in the `civicrm_pivotreportcache` table.
- Everywhere where `civicrm_api3($EntityName, 'get', $apiParams);` or the Civi APi is called directly for a report should be replaced with a call to the version of the reports method e.g `getCount`, `get` exposed via the Pivot API.

## update on making the extension work with Leave Report
I tried to see how to get the Leave Report working with the pivot report extension as is, I came up with the following API call:
```php
  $result = civicrm_api3('LeaveRequest', 'get', array(
    'sequential' => 1,
    'return' => array("contact_id", "type_id", "status_id", "request_type"),
    'api.Contact.get' => array(
      'id' => "\$value.contact_id", 
      'return' => array("display_name", "birth_date", "gender_id")
    ),
    'api.HRJobContract.get' => array(
      'contact_id' => "\$value.contact_id", 
      'return' => array("position", "title", "contract_type", "period_start_date", "period_end_date", "is_current", "jobcontract_revision_id"), 
     
      'api.HRJobHour.get' => array(
        'jobcontract_revision_id' => "\$value.jobcontract_revision_id"
      ),
      
      'api.HRJobPay.get' => array(
        'jobcontract_revision_id' => "\$value.jobcontract_revision_id",
        'sequential' => 1,
      ),
      'api.HrJobRoles.get' => array('sequential' => 1, 'job_contract_id' => "\$value.id"),
    ),
    'api.LeaveRequestDate.get' => array(
      'leave_request_id' => "\$value.id"),
      'api.LeaveBalanceChange.get' => array('source_id' => "\$value.id", 'source_type' => "leave_request_day"),
  ));
```
The results for some fields would still need to be modified either via handlers or in the logic when results are fetched e.g Employee Age group(by modifying the birth_date field), Employee Age, Absence Is Credit(by modifying the request_type field), Absence Day of Week, Absence Start Month, Absence End month....
The API calls to `api.HRJobPay.get` and `api.HRJobHour.get` did not return any results, This seems to be because the `jobcontract_revision_id` field returned by the Job contract API is not a true field of the Entity per say because the field actually belongs to the HRJobDetails Entity.

## Update on other extensions injecting their report.
I tried making the People report to reside in L&A extension and it was successful to some extent. 
- I had to add the Contact entity to the supported entities in the pivot report extension
- I had to add the template for the report display to the pivot report extension
- The other files were added to the L&A extension i.e `CRM_PivotCache_GroupContact and `CRM_PivotData_DataContact` but I could not add them in the `HRLeaveAndAbsences` namespace but outside it due to [this](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/c976e07d2fd40ef0a7f61bc22a3c93c73544c0f9/CRM/PivotReport/Entity.php#L220), i.e the namespace for the extending classes are already hardcoded.
