### PR TITLE
Entities Missing From Reports

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -164,7 +164,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @return string
    */
   protected function getPath($index, $page = NULL) {
-    return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
+    return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT).'_'.rand(10000, 99999);;
   }
 
 

--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -164,7 +164,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @return string
    */
   protected function getPath($index, $page = NULL) {
-    return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT).'_'.rand(10000, 99999);;
+    return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
   }
 
 

--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -116,7 +116,7 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {
-    return substr($row['Activity Date Time'], 0, 10);
+    return substr($row['Activity Date Time'], 0, 10).'_'.$row['Activity ID'];
   }
 
   /**

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -174,7 +174,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {
-    return substr($row[ts('Case Start Date')], 0, 10);
+    return substr($row[ts('Case Start Date')], 0, 10).'_'.$row[ts('Case ID')];
   }
 
   /**

--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -99,7 +99,7 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {
-    return substr($row['Date Received'], 0, 10);
+    return substr($row['Date Received'], 0, 10).'_'.$row['Contribution ID'];
   }
 
   /**

--- a/CRM/PivotData/DataMembership.php
+++ b/CRM/PivotData/DataMembership.php
@@ -73,7 +73,7 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
    * @inheritdoc
    */
   protected function getEntityIndex(array $row) {
-    return substr($row['Member Since'], 0, 10);
+    return substr($row['Member Since'], 0, 10).'_'.$row['Membership ID'];
   }
 
   /**


### PR DESCRIPTION
## Overview ##
In a site with a lot of cases, a good number of them were missing on the pivot reports.

## Issue ##
On looking into the code, when entities are cached, the path column (unique path name for cache element) is not unique in few cases. The main part of this 'path' is $index which is usually the a 'date' like ('start date' for cases, 'date received' for contributions etc). So I guess if a number of cases are added with same start date for example, they are overwritten in cache table and so missing from reports.

## Possible Resolution ##
Adding entity ID as part of 'path' to make it unique fixes the issue