### PR TITLE
GS-123: Fix getPaginatedResults Page Number Logic

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -364,6 +364,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $apiParams['options']['offset'] = $offset;
     $entities = civicrm_api3($this->apiEntityName, 'get', $apiParams);
     $formattedEntities = $this->formatResult($entities['values']);
+    $indexes = array();
 
     unset($entities);
 
@@ -375,9 +376,12 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
         break;
       }
 
-      if ($split['info']['index'] !== $index) {
+      if (!in_array($split['info']['index'], array_keys($indexes))) {
         $page = 0;
         $index = $split['info']['index'];
+      }
+      else {
+        $page = $indexes[$index];
       }
 
       $result[] = new CRM_PivotData_DataPage($split['data'], $index, $page++, $split['info']['nextOffset'], $split['info']['multiValuesOffset']);
@@ -388,6 +392,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
       $offset = $split['info']['nextOffset'];
       $multiValuesOffset =  $split['info']['multiValuesOffset'];
+      $indexes[$index] = $page;
     }
 
     return $result;


### PR DESCRIPTION
## Overview ##
In a site with a lot of cases, a good number of them were missing on the pivot reports.

## Issue ##
On looking into the code, getPaginatedResults() checks for previous index name and if its the same it increments the page number and if the index is different it resets page number to 0. However in certain cases there are indexes which are not sequential but have the same index name. In such cases the page number is wrongly set to 0 and the old page entities are missed.

##  Resolution ##
Maintain an array of index names and page numbers instead of a single index name.