### PR TITLE
GS-130: Add Specific Custom Fields to Prospects Report and Customize Labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+resources/custom_labels/*
+!resources/custom_labels/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-resources/custom_labels/*
-!resources/custom_labels/.gitkeep
+resources/customizations/*
+!resources/customizations/.gitkeep

--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -189,7 +189,7 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
         $result[$key]['optionValues'] = $this->getOptionValues($value);
       }
 
-      $this->replaceFieldTitlesWithCustomLabels($result);
+      $this->replaceCustomizedFieldLabels($result);
       $this->fields = $result;
     }
 
@@ -224,8 +224,8 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
   public function getDateFields() {
     $result = parent::getDateFields();
 
-    $result[] = $this->replaceCustomLabels(ts('Activity Date'));
-    $result[] = $this->replaceCustomLabels(ts('Activity Expire Date'));
+    $result[] = $this->replaceCustomLabel(ts('Activity Date'));
+    $result[] = $this->replaceCustomLabel(ts('Activity Expire Date'));
 
     return $result;
   }

--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -189,7 +189,7 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
         $result[$key]['optionValues'] = $this->getOptionValues($value);
       }
 
-      $this->replaceCustomLabelsForFieldTitles($result);
+      $this->replaceFieldTitlesWithCustomLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataActivity.php
+++ b/CRM/PivotData/DataActivity.php
@@ -189,6 +189,7 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
         $result[$key]['optionValues'] = $this->getOptionValues($value);
       }
 
+      $this->replaceCustomLabelsForFieldTitles($result);
       $this->fields = $result;
     }
 
@@ -223,8 +224,8 @@ class CRM_PivotData_DataActivity extends CRM_PivotData_AbstractData {
   public function getDateFields() {
     $result = parent::getDateFields();
 
-    $result[] = ts('Activity Date');
-    $result[] = ts('Activity Expire Date');
+    $result[] = $this->replaceCustomLabels(ts('Activity Date'));
+    $result[] = $this->replaceCustomLabels(ts('Activity Expire Date'));
 
     return $result;
   }

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -157,7 +157,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
    * @return array
    */
   protected function getManager($contacts) {
-    $caseManagerLabel = $this->replaceCustomLabels(ts('Case Manager Display Name'));
+    $caseManagerLabel = $this->replaceCustomLabel(ts('Case Manager Display Name'));
 
     foreach ($contacts as $contact) {
       if (!empty($contact['manager']) && (int) $contact['manager'] === 1) {
@@ -247,7 +247,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceFieldTitlesWithCustomLabels($result);
+      $this->replaceCustomizedFieldLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -63,7 +63,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
   }
 
   /**
-   * Builds an array with client's data impleded for each field, to handle cases
+   * Builds an array with client's data imploded for each field, to handle cases
    * with multiple clients.
    *
    * @param array $clients
@@ -157,16 +157,18 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
    * @return array
    */
   protected function getManager($contacts) {
+    $caseManagerLabel = $this->replaceCustomLabels(ts('Case Manager Display Name'));
+
     foreach ($contacts as $contact) {
       if (!empty($contact['manager']) && (int) $contact['manager'] === 1) {
         return array(
-          ts('Case Manager Display Name') => $contact['display_name'],
+          $caseManagerLabel => $contact['display_name'],
         );
       }
     }
 
     return array(
-      ts('Case Manager Display Name') => '',
+      $caseManagerLabel => '',
     );
   }
 
@@ -245,6 +247,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
         }
       }
 
+      $this->replaceCustomLabelsForFieldTitles($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataCase.php
+++ b/CRM/PivotData/DataCase.php
@@ -247,7 +247,7 @@ class CRM_PivotData_DataCase extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceCustomLabelsForFieldTitles($result);
+      $this->replaceFieldTitlesWithCustomLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -160,6 +160,7 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
         }
       }
 
+      $this->replaceCustomLabelsForFieldTitles($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -160,7 +160,7 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceCustomLabelsForFieldTitles($result);
+      $this->replaceFieldTitlesWithCustomLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -160,7 +160,7 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceFieldTitlesWithCustomLabels($result);
+      $this->replaceCustomizedFieldLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataMembership.php
+++ b/CRM/PivotData/DataMembership.php
@@ -137,6 +137,7 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
         }
       }
 
+      $this->replaceCustomLabelsForFieldTitles($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataMembership.php
+++ b/CRM/PivotData/DataMembership.php
@@ -137,7 +137,7 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceFieldTitlesWithCustomLabels($result);
+      $this->replaceCustomizedFieldLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataMembership.php
+++ b/CRM/PivotData/DataMembership.php
@@ -137,7 +137,7 @@ class CRM_PivotData_DataMembership extends CRM_PivotData_AbstractData {
         }
       }
 
-      $this->replaceCustomLabelsForFieldTitles($result);
+      $this->replaceFieldTitlesWithCustomLabels($result);
       $this->fields = $result;
     }
 

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -95,9 +95,9 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
             )
           );
 
-          $label = $this->replaceCustomLabels(ts('Pledge Balance'));
+          $pledgeBalanceLabel = $this->replaceCustomLabel(ts('Pledge Balance'));
           $paymentValues = $this->getRowValues($pledge['values'][0], 'pledge');
-          $paymentValues[$label] = CRM_Utils_Money::format((float) $paymentValues['pledge.pledge_amount'] - (float) $paymentValues[$fields['pledge.pledge_total_paid']], NULL, NULL, TRUE);
+          $paymentValues[$pledgeBalanceLabel] = CRM_Utils_Money::format((float) $paymentValues['pledge.pledge_amount'] - (float) $paymentValues[$fields['pledge.pledge_total_paid']], NULL, NULL, TRUE);
         }
       }
 
@@ -214,7 +214,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
         }
       }
 
-      $this->replaceFieldTitlesWithCustomLabels($result);
+      $this->replaceCustomizedFieldLabels($result);
       $this->fields = $result;
     }
 
@@ -230,8 +230,14 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
   protected function loadAdditionalCustomFields(&$fields) {
     foreach ($this->customFields as $group => $customFields) {
       foreach ($customFields as $fieldData) {
-        $field = $this->loadCustomFieldData($fieldData);
-        $fields[$group][$field['name']] = $field;
+        $fieldName = CRM_Utils_Array::value('name', $fieldData);
+        $groupName = CRM_Utils_Array::value('group', $fieldData);
+
+        $field = $this->loadCustomFieldData($fieldName, $groupName);
+
+        if (!empty($field)) {
+          $fields[$group][$field['name']] = $field;
+        }
       }
     }
   }

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -19,7 +19,10 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
     $params = array(
       'sequential' => 1,
       'is_deleted' => 0,
-      'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
+      'api.Contact.get' => array(
+        'id' => '$value.client_id',
+        'return' => $this->getClientFields(),
+      ),
       'api.ProspectConverted.get' => array('prospect_case_id' => '$value.id'),
       'return' => array_merge($this->getCaseFields(), array('subject', 'contacts', 'contact_id')),
       'options' => array(
@@ -29,6 +32,29 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
     );
 
     return $params;
+  }
+
+  /**
+   * Builds array of fields to be returned in API call to get client data.
+   */
+  private function getClientFields() {
+    $result = array(
+      'id',
+      'contact_type',
+      'contact_sub_type',
+      'display_name',
+    );
+    $fields = array_keys($this->getFields());
+
+    foreach ($fields as $currentField) {
+      $fieldParts = explode('.', $currentField);
+
+      if ($fieldParts[0] === 'client' && !in_array($fieldParts[1], $result)) {
+        $result[] = $fieldParts[1];
+      }
+    }
+
+    return $result;
   }
 
   /**
@@ -170,6 +196,9 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
         $fields['pledge'][$fieldKey] = $pledgeFields[$fieldKey];
       }
 
+      // Include Additional Custom Fields
+      $this->loadAdditionalCustomFields($fields);
+
       $result = array();
       foreach ($groups as $group => $entity) {
         foreach ($fields[$group] as $key => $value) {
@@ -179,16 +208,32 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
           $result[$group . '.' . $key] = $value;
 
           if (is_array($value)) {
-            $result[$group . '.' . $key]['optionValues'] = $this->getOptionValues($value, $entity);
+            $fieldEntity = empty($value['entity']) ? $entity : $value['entity'];
+            $result[$group . '.' . $key]['optionValues'] = $this->getOptionValues($value, $fieldEntity);
           }
         }
       }
 
-      $this->replaceCustomLabelsForFieldTitles($result);
+      $this->replaceFieldTitlesWithCustomLabels($result);
       $this->fields = $result;
     }
 
     return $this->fields;
+  }
+
+  /**
+   * Loads additional fields to be added to report, as set in customization
+   * files, into the given array.
+   *
+   * @param array $fields
+   */
+  protected function loadAdditionalCustomFields(&$fields) {
+    foreach ($this->customFields as $group => $customFields) {
+      foreach ($customFields as $fieldData) {
+        $field = $this->loadCustomFieldData($fieldData);
+        $fields[$group][$field['name']] = $field;
+      }
+    }
   }
 
 }

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -69,8 +69,9 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
             )
           );
 
+          $label = $this->replaceCustomLabels(ts('Pledge Balance'));
           $paymentValues = $this->getRowValues($pledge['values'][0], 'pledge');
-          $paymentValues[ts('Pledge Balance')] = CRM_Utils_Money::format((float) $paymentValues['pledge.pledge_amount'] - (float) $paymentValues[$fields['pledge.pledge_total_paid']], NULL, NULL, TRUE);
+          $paymentValues[$label] = CRM_Utils_Money::format((float) $paymentValues['pledge.pledge_amount'] - (float) $paymentValues[$fields['pledge.pledge_total_paid']], NULL, NULL, TRUE);
         }
       }
 
@@ -105,7 +106,6 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
       }
 
       $keys['case'] = CRM_Case_DAO_Case::fieldKeys();
-      $result = array();
 
       // Now get Custom Fields of Case entity.
       $customFieldsResult = CRM_Core_DAO::executeQuery(
@@ -170,6 +170,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
         $fields['pledge'][$fieldKey] = $pledgeFields[$fieldKey];
       }
 
+      $result = array();
       foreach ($groups as $group => $entity) {
         foreach ($fields[$group] as $key => $value) {
           if (!empty($value['name']) && !empty($keys[$group][$value['name']])) {
@@ -183,9 +184,11 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
         }
       }
 
+      $this->replaceCustomLabelsForFieldTitles($result);
       $this->fields = $result;
     }
 
     return $this->fields;
   }
+
 }


### PR DESCRIPTION
## Overview
GS have requested that we add four additional fields to the prospect pivot report, and that we re-name a couple of others. This poses the problem of doing this changes specific to Greenhouse Sport's installation, 

### Field name updates

- "Prospect client type" should become "Contact Type"
- "Prospect client subtype" should become 'Org Type"

### New fields to add to report
- Supplier Sub-Type
- Donor Sub-Type
- Education Sub-Type
- Gov Sub-Type

## Before
There was no way to add custom fields per installation to prospect report, nor a way to customize field labels used on the pivot report.

## After
Implemented the possibility to add a json configuration file per Data entity (Activity, Membership, Case, Contribution, Prospect) to modify its behaviour, by configuring field label mappings to alter field labels and to add specific client custom fields to prospects report.

## Technical Details
This is a sample file that achives the customizations required by Greenhouse:
```json
{
  "field_labels": {
    "Prospect Client Type": "Contact Type",
    "Prospect Client Subtype": "Org Type"
  },
  "custom_fields": {
    "client": {
      "Contact_Type_Supplier": {
        "entity": "Contact",
        "group": "GS_Relationship_Type",
        "name": "Contact_Type_Supplier"
      },
      "Contact_Type_Donor": {
        "entity": "Contact",
        "group": "GS_Relationship_Type",
        "name": "Contact_Type_Donor"
      },
      "Contact_Type_Education": {
        "entity": "Contact",
        "group": "GS_Relationship_Type",
        "name": "Contact_Type_Education"
      },
      "Contact_Type_Gov": {
        "entity": "Contact",
        "group": "GS_Relationship_Type",
        "name": "Contact_Type_Gov"
      }
    }
  }
}
```

## Comments
Discussed approach with Ellen, asking if we should think of making this manageable via an admin interface and storing settings on database instead, but the decision was made to just include a settings file, as this ticket is quite urgent for the client and there is no current need to be able to manage this. We could however build on this in the future, to implement manageable customized labels and fields to be included on the report, if we find it is a welcome addition to the extension.