### PR TITLE
PCHR-3846: Add leave report filter

### DIFF
--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -367,7 +367,7 @@ CRM.PivotReport.PivotTable = (function ($) {
    * it resolves to the default value.
    */
   PivotTable.prototype.initCustomFilterDefaultValues = function () {
-    this.customFilterForm.find('input, select, textarea')
+    this.customFilterForm.find('[name]')
       .each(function (index, element) {
         var input = $(element);
         var inputName = input.attr('name');

--- a/templates/CRM/PivotReport/Page/LeaveReport.tpl
+++ b/templates/CRM/PivotReport/Page/LeaveReport.tpl
@@ -116,42 +116,59 @@
           return 'No';
         }
       },
-      'hiddenAttributes': ['Is TOIL', 'Absence Amount', 'Absence Calculation Unit', 'Is TOIL'],
-      'resolveCustomFilterDefaultValues': function () {
-        var today = moment().format(this.DEFAULT_DATE_FORMAT);
-
-        return CRM.api3('AbsencePeriod', 'get', {
-          'sequential': 1,
-          'start_date': { '<=': today },
-          'end_date': { '>=': today },
-          'options': { 'limit': 1 }
-        })
-          .then(function (periods) {
-            var period = _.first(periods.values);
-
-            if (!period) {
-              return;
-            }
-
-            return {
-              from: period.start_date,
-              to: period.end_date
-            };
-          });
-      },
-      'customFilter': function (record) {
-        var dates = {
-          start: moment(this.customFilterValues.from),
-          end: moment(this.customFilterValues.to)
-        };
-        var request = {
-          start: moment(record['Absence Start Date']),
-          end: moment(record['Absence End Date'])
-        };
-
-        return request.start.isSameOrAfter(dates.start) && request.end.isSameOrBefore(dates.end);
-      }
+      'hiddenAttributes': ['Absence Amount', 'Absence Calculation Unit', 'Is TOIL'],
+      'resolveCustomFilterDefaultValues': resolveCustomFilterDefaultValues,
+      'customFilter': customFilter
     });
+
+    /**
+     * Returns true for leave request records that are within the custom filter
+     * dates selected by the user.
+     *
+     * @param {Object} record - the leave request record
+     * @return {Boolean}
+     */
+    function customFilter (record) {
+      var dates = {
+        start: moment(this.customFilterValues.from),
+        end: moment(this.customFilterValues.to)
+      };
+      var request = {
+        start: moment(record['Absence Start Date']),
+        end: moment(record['Absence End Date'])
+      };
+
+      return request.start.isSameOrAfter(dates.start) && request.end.isSameOrBefore(dates.end);
+    }
+
+    /**
+     * Returns the default dates for the custom filters. These resolve to the
+     * current absence period start and end dates.
+     *
+     * @return {Promise} resolves to an object.
+     */
+    function resolveCustomFilterDefaultValues () {
+      var today = moment().format(this.DEFAULT_DATE_FORMAT);
+
+      return CRM.api3('AbsencePeriod', 'get', {
+        'sequential': 1,
+        'start_date': { '<=': today },
+        'end_date': { '>=': today },
+        'options': { 'limit': 1 }
+      })
+        .then(function (periods) {
+          var period = _.first(periods.values);
+
+          if (!period) {
+            return;
+          }
+
+          return {
+            from: period.start_date,
+            to: period.end_date
+          };
+        });
+    }
   });
 </script>
 {/literal}

--- a/templates/CRM/PivotReport/Page/PeopleReport.tpl
+++ b/templates/CRM/PivotReport/Page/PeopleReport.tpl
@@ -34,25 +34,7 @@
       'cacheBuilt': {/literal}{$cacheBuilt|var_export:true}{literal},
       'filter': true,
       'filterField': 'Contract Start Date',
-      'customFilter': function (record) {
-        var endsAfterDate, hasValidStartDates, startsBeforeDate;
-        var date = moment(this.customFilterValues.headCountOnDate);
-        var contract = {
-          start: moment(record['Contract Start Date']),
-          end: moment(record['Contract End Date'])
-        };
-        var role = {
-          start: moment(record['Role Start Date']),
-          end: moment(record['Role End Date'])
-        };
-
-        hasValidStartDates = contract.start.isValid() && role.start.isValid();
-        startsBeforeDate = contract.start.isSameOrBefore(date) && role.start.isSameOrBefore(date);
-        endsAfterDate = (!contract.end.isValid() || date.isBetween(contract.start, contract.end, null, '[]'))
-          && (!role.end.isValid() || date.isBetween(role.start, role.end, null, '[]'));
-
-        return hasValidStartDates && startsBeforeDate && endsAfterDate;
-      },
+      'customFilter': customFilter,
       'initialLoad': {
         'limit': 1000,
         'message': 'There are more than 1000 items, getting only items from last 30 days.',
@@ -73,6 +55,33 @@
         });
       }
     });
+
+    /**
+     * Returns true when the people record has a contract and a job role that
+     * fall between the custom filter dates selected by the user.
+     *
+     * @param {Object} record - the people record.
+     * @return {Boolean}
+     */
+    function customFilter (record) {
+      var endsAfterDate, hasValidStartDates, startsBeforeDate;
+      var date = moment(this.customFilterValues.headCountOnDate);
+      var contract = {
+        start: moment(record['Contract Start Date']),
+        end: moment(record['Contract End Date'])
+      };
+      var role = {
+        start: moment(record['Role Start Date']),
+        end: moment(record['Role End Date'])
+      };
+
+      hasValidStartDates = contract.start.isValid() && role.start.isValid();
+      startsBeforeDate = contract.start.isSameOrBefore(date) && role.start.isSameOrBefore(date);
+      endsAfterDate = (!contract.end.isValid() || date.isBetween(contract.start, contract.end, null, '[]'))
+        && (!role.end.isValid() || date.isBetween(role.start, role.end, null, '[]'));
+
+      return hasValidStartDates && startsBeforeDate && endsAfterDate;
+    }
   });
 </script>
 {/literal}


### PR DESCRIPTION
## Overview

This PR adds date filters to the admin's leave report.

## Before
![leave reports hr17 9000 20](https://user-images.githubusercontent.com/1642119/41633829-c51d77ca-740e-11e8-830a-7fb15bfead80.png)

## After
![anim](https://user-images.githubusercontent.com/1642119/41633802-98bea532-740e-11e8-8879-c301a3ab234a.gif)
* Note: please ignore the date picker's border. See the comments for more information.


## Technical details

The way default values for the custom filters are generated changed since for the leave report they depend on the current period provided by the API. The new sequence is as follows:

* When loading the data for the report, also load the default values for the custom filter, if a `resolveCustomFilterDefaultValues` function is provided in the report configuration. This function must return a promise which resolves to an object containing the default values for each one of the inputs.
```js
// from the leave report configuration:
'resolveCustomFilterDefaultValues': function () {
  var today = moment().format(this.DEFAULT_DATE_FORMAT);

  return CRM.api3('AbsencePeriod', 'get', {
    'sequential': 1,
    'start_date': { '<=': today },
    'end_date': { '>=': today },
    'options': { 'limit': 1 }
  })
    .then(function (periods) {
      var period = _.first(periods.values);

      if (!period) {
        return;
      }

      // *from* and *to* are the name of the form inputs for the custom filters
      // in the leave report:
      return {
        from: period.start_date,
        to: period.end_date
      };
    });
},
```
* As explained before, this `resolveCustomFilterDefaultValues` is executed when loading the report data:
```js
// From the pivot table js file:
PivotTable.prototype.initPivotDataLoading = function () {
  // ...
  $.when(
    CRM.api3(apiCalls),
    this.resolveCustomFilterDefaultValues()
  )
    .then(function (results) {
      // ...
    });
};

PivotTable.prototype.resolveCustomFilterDefaultValues = function () {
  var dateInputsDefaultValues = this.getDefaultValuesForDateInputs();

  return $.when()
    .then(function () {
      return this.config.resolveCustomFilterDefaultValues
        ? this.config.resolveCustomFilterDefaultValues()
        : {};
    }.bind(this))
    .then(function (defaultValues) {
      // it also passes the date input default values so it's not necessary to define a
      // resolver just for date inputs of which their default is today:
      this.customFilterDefaultValues = _.extend({}, dateInputsDefaultValues, defaultValues);
    }.bind(this));
};

PivotTable.prototype.getDefaultValuesForDateInputs = function () {
  var defaultValues = {};
  var today = moment().format(this.DEFAULT_DATE_FORMAT);

  this.customFilterForm.find('.crm-ui-datepicker').each(function () {
    var inputName = $(this).attr('name');

    defaultValues[inputName] = today;
  });

  return defaultValues;
};
```
* After loading the pivot table data and the custom field default values, and during the post render sequence, the default values are assigned to the custom field inputs:
```js
PivotTable.prototype.initCustomFilterDefaultValues = function () {
  this.customFilterForm.find('input, select, textarea')
    .each(function (index, element) {
      var input = $(element);
      var inputName = input.attr('name');
      var inputDefaultValue = this.customFilterDefaultValues[inputName];

      if (!inputDefaultValue) {
        return;
      }

      input.on('change', function () {
        var isValueEmpty = _.isEmpty(input.val());

        if (isValueEmpty) {
          input.val(inputDefaultValue).change();
        }
      });
      input.change();
    }.bind(this));
};
```
If the input changes and the value is empty, it will use the default value instead.
* Finally, for the actual filtering, the `customFilter` function was defined as follows:
```js
'customFilter': function (record) {
  var dates = {
    start: moment(this.customFilterValues.from),
    end: moment(this.customFilterValues.to)
  };
  var request = {
    start: moment(record['Absence Start Date']),
    end: moment(record['Absence End Date'])
  };

  return request.start.isSameOrAfter(dates.start) && request.end.isSameOrBefore(dates.end);
}
```

## Comments

* For more information about report's custom filtering, please read the following PR:
https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/pull/116
* This PR is related to this other PR: https://github.com/compucorp/org.civicrm.shoreditch/pull/111 since the later fixes an issue with the date picker borders.