### PR TITLE
CPS-342: Remove is_current_revision parameter from count api

### DIFF
--- a/CRM/PivotData/DataContribution.php
+++ b/CRM/PivotData/DataContribution.php
@@ -171,7 +171,6 @@ class CRM_PivotData_DataContribution extends CRM_PivotData_AbstractData {
    */
   public function getCount(array $params = array()) {
     $apiParams = array(
-      'is_current_revision' => 1,
       'is_deleted' => 0,
       'is_test' => 0,
     );


### PR DESCRIPTION
## Overview
This pr removes the is_current_revision parameter from the contribution count api call to remove the discrepancies between count api and data api calls for contribution.While sending the api call for fetching the contribution count we are attaching an extra parameter by the name of is_current_revision as can be seen [here](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/DataContribution.php#L174) but while fetching the actual data the same parameter was not being sent as can be seen [here](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/DataContribution.php#L19-L21) This led to different data in both the apis.

## Before
The count of data was not getting effected even after new records were being inserted.

## After
Removal of the extra is_current_revison results in correct count being fetched through the api.