### PR TITLE
GSSPRT-95: Fix Bug Fetching Rows On Report

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -11,7 +11,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
    * Limit value for API 'get' action on source entity. Used on rebuilding
    * Pivot Data.
    */
-  const ROWS_API_LIMIT = 1000;
+  const ROWS_API_LIMIT = 3000;
 
   /**
    * Maximum number of data rows per page (single cache row).


### PR DESCRIPTION
## Overview
This PR solves a problem that appears on a specific report that handles a relatively big amount of data.
The caching mechanism was discarding some rows that should appear on the report.

In some way, the batch size specified on the constant `ROWS_API_LIMIT` was causing the problem, and as a temporal solution, we have increased the number. The underlying problematic situation will be handled soon.


## Before
Some of the results expected were omitted on the output generated for the report.

## After
All the information expected is correctly being displayed. 