### PR TITLE
GSSPRT-100: Fix Issue With Missing Entities Data

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -159,12 +159,20 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * Gets a cache path string by specified index and page.
    *
    * @param string $index
+   *   Cache index.
    * @param int $page
-   *
+   *   Page number
+   * @param bool $addUniqueSuffix
+   *  Whether to add a unique suffix or not.
    * @return string
    */
-  protected function getPath($index, $page = NULL) {
-    return 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
+  protected function getPath($index, $page = NULL, $addUniqueSuffix = TRUE) {
+    $path = 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
+    if ($addUniqueSuffix) {
+      $path .= '_' . uniqid();
+    }
+
+    return $path;
   }
 
 

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -15,9 +15,9 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
   protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
     if (!empty($params['keyvalue_from'])) {
       $whereStartDate = CRM_Core_DAO::createSQLFilter(
-        'path',
+        'LEFT(path, LENGTH(path) - 14)',
         array(
-          '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page),
+          '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page, FALSE),
         ),
         'String'
       );
@@ -27,9 +27,9 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
 
     if (!empty($params['keyvalue_to'])) {
       $whereEndDate = CRM_Core_DAO::createSQLFilter(
-        'path',
+        'LEFT(path, LENGTH(path) - 14)',
         array(
-          '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999),
+          '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999, FALSE),
         ),
         'String'
       );

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -15,6 +15,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
   protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
     if (!empty($params['keyvalue_from'])) {
       $whereStartDate = CRM_Core_DAO::createSQLFilter(
+        // Remove the unique suffix added to the path.
         'LEFT(path, LENGTH(path) - 14)',
         array(
           '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page, FALSE),
@@ -27,6 +28,7 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
 
     if (!empty($params['keyvalue_to'])) {
       $whereEndDate = CRM_Core_DAO::createSQLFilter(
+      // Remove the unique suffix added to the path.
         'LEFT(path, LENGTH(path) - 14)',
         array(
           '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999, FALSE),

--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -364,6 +364,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $apiParams['options']['offset'] = $offset;
     $entities = civicrm_api3($this->apiEntityName, 'get', $apiParams);
     $formattedEntities = $this->formatResult($entities['values']);
+    $indexes = [];
 
     unset($entities);
 
@@ -375,9 +376,12 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
         break;
       }
 
-      if ($split['info']['index'] !== $index) {
+      $index = $split['info']['index'];
+      if (!in_array($index, array_keys($indexes))) {
         $page = 0;
-        $index = $split['info']['index'];
+      }
+      else {
+        $page = $indexes[$index];
       }
 
       $result[] = new CRM_PivotData_DataPage($split['data'], $index, $page++, $split['info']['nextOffset'], $split['info']['multiValuesOffset']);
@@ -388,6 +392,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
       $offset = $split['info']['nextOffset'];
       $multiValuesOffset =  $split['info']['multiValuesOffset'];
+      $indexes[$index] = $page;
     }
 
     return $result;

--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -23,7 +23,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
       'api.ProspectConverted.get' => array('prospect_case_id' => '$value.id'),
       'return' => array_merge($this->getCaseFields(), array('subject', 'contacts', 'contact_id')),
       'options' => array(
-        'sort' => 'id ASC',
+        'sort' => 'start_date ASC, id ASC',
         'limit' => self::ROWS_API_LIMIT,
       ),
     );


### PR DESCRIPTION
## Overview
There are some issues with missing entities data in the pivot report. For example in the prospect pivot report for a client, some prospects that were present were missing in the prospect pivot report. The previous temporary fix for this was to increase the value of the [ROWS_API_LIMIT](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/AbstractData.php#L14) constant which seems to fix this issue. This PR properly fixes this issue.

## Before
There were missing entities data in the pivot report for an entity.

## After
The issue with missing entities data in the pivot report for an entity is fixed.

## Technical Details
The pivot report extension has business logic that expects the index for an entity (Usually the start data) to be ordered either in ascending or descending order, [See](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/DataCase.php#L25). When the data is not ordered, because when building the pivot report cache for entities, it does so in batches defined by the `ROWS_API_LIMIT` value, for entities that has total greater than the value of this constant, on subsequent runs, the value cached on the first run is overridden and [updated](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotReport/BAO/PivotReportCache.php#L148-L155).
The prospect report does not have an order set for the [start date](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/DataProspect.php#L26) when fetching report, hence there will be values of same start date index that can override the first index cached in the second run, hence the reason why we have issues with this entity report. Fixing this is as simple as setting the start_date to be in ascending order.
```php
        'sort' => 'start_date ASC, id ASC',
```

However there might be another issue which is that on the second run, an index(start_date) that was cached in the first run still has some left over data to be cached in the second run and this will override the previous values cached. To fix this issue, a unique key is added to the `path` for each run so that on subsequent runs, the previous values is not updated for the same index path.
```php
  protected function getPath($index, $page = NULL, $addUniqueSuffix = TRUE) {
    $path = 'data_' . $index . '_' . str_pad($page, 6, '0', STR_PAD_LEFT);
    if ($addUniqueSuffix) {
      $path .= '_' . uniqid();
    }

    return $path;
  }
```
A third issue is the fact that some data was wrongly indexed . For example an index of `data_2020-03-04` in the `civicrm_pivotreportcache` table could be storing data with dates that are unrelated to the index. This was an issue fixed in the `getPaginatedResults` function due to the loop using an old index because the new index was not properly set.