### PR TITLE
PS-527: Fix issue with NULL schema version upon install

### DIFF
--- a/pivotreport.php
+++ b/pivotreport.php
@@ -50,6 +50,15 @@ function pivotreport_civicrm_enable() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function pivotreport_civicrm_postInstall() {
+  _pivotreport_civix_civicrm_postInstall();
+}
+
+/**
  * Implements hook_civicrm_disable().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable


### PR DESCRIPTION
## Overview
When the Pivot extension is installed on a fresh site, the schema version for the extension is NULL in the `civicrm_extension` table even though the extension has upgraders and the schema version is supposed to be set to the latest upgrader number, in this case it should have been `0012`. This causes an issue on the extensions page, where a notice is shown that there are pending updates for pivot report extension.

## Before 
The issue describe above exists

## After
We recently updated the civicrm base upgrader and civix classes in this PR: https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/pull/124. Initially, before the upgrade, the function responsible for setting the current revision for the extension was invoked on the onInstall function, see: https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/cea556fb446c7e19a7cf3e96b59cafd031bbaabb/CRM/PivotReport/Upgrader/Base.php#L261, but with the changes, the function is now called on the `onPostInstall` function.
The Pivot report extension does not implement this hook in the `pivotreport.php` file, hence the `onPostInstall` is never triggered and the current revision is never set, hence the reason why it is NULL.

The issue is fixed by implementing the postInstall hook in the extension.