### PR TITLE
GSSPRT-124: Fix Issue With Saved Reports Not Displaying in The Report List

### DIFF
--- a/CRM/PivotReport/BAO/PivotReportConfig.php
+++ b/CRM/PivotReport/BAO/PivotReportConfig.php
@@ -10,6 +10,7 @@ class CRM_PivotReport_BAO_PivotReportConfig extends CRM_PivotReport_DAO_PivotRep
       'return' => array('label'),
       'options' => array(
         'sort' => 'label ASC',
+        'limit' => 0,
       ),
     ));
 


### PR DESCRIPTION
## Problem
When a new pivot report is saved, the newly saved report does not show up in the dropdown list.

<img width="1280" alt="Prospect Pivot Report  NEU 2021-05-28 15-26-42" src="https://user-images.githubusercontent.com/6951813/119999112-4ca2c700-bfc9-11eb-98f7-0cfa064bf054.png">

## Solution
The issue was because the API call for fetching the list of saved pivot report configs was fetching 25 configs by default. The fix was to set the call to fetch configs without a limit.