### PR TITLE
FEMSSPRT-44: Fix Activity Report Problem on Loading

### DIFF
--- a/CRM/PivotData/AbstractData.php
+++ b/CRM/PivotData/AbstractData.php
@@ -76,7 +76,7 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
   /**
    * Name of data group.
    *
-   * @var string 
+   * @var string
    */
   protected $name = NULL;
 
@@ -364,7 +364,6 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
     $apiParams['options']['offset'] = $offset;
     $entities = civicrm_api3($this->apiEntityName, 'get', $apiParams);
     $formattedEntities = $this->formatResult($entities['values']);
-    $indexes = [];
 
     unset($entities);
 
@@ -376,12 +375,9 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
         break;
       }
 
-      $index = $split['info']['index'];
-      if (!in_array($index, array_keys($indexes))) {
+      if ($split['info']['index'] !== $index) {
         $page = 0;
-      }
-      else {
-        $page = $indexes[$index];
+        $index = $split['info']['index'];
       }
 
       $result[] = new CRM_PivotData_DataPage($split['data'], $index, $page++, $split['info']['nextOffset'], $split['info']['multiValuesOffset']);
@@ -392,7 +388,6 @@ abstract class CRM_PivotData_AbstractData implements CRM_PivotData_DataInterface
 
       $offset = $split['info']['nextOffset'];
       $multiValuesOffset =  $split['info']['multiValuesOffset'];
-      $indexes[$index] = $page;
     }
 
     return $result;


### PR DESCRIPTION
### Overview
This PR solved the error presented on Activity reports, which made the page keep loading indefinitely. 

### Before
On Reports > Pivot Report > Activity, the progress bar keep loading without end, with numbers greater than the 100%
![image-20210525-080405](https://user-images.githubusercontent.com/74304572/121911793-41d28b00-cd5a-11eb-89ec-e2bd7e6b2eb0.png)

### After
The page finishes loading correctly.
<img width="1622" alt="Screen Shot 2021-06-14 at 21 49 49" src="https://user-images.githubusercontent.com/74304572/121912147-865e2680-cd5a-11eb-935b-fdda445864c0.png">

## Technical Details
The fix consists of not overriding the `$page` variable that is being passed on the `getPaginatedResults` method. This variable keeps track of the last page used for a giving index, when called in `rebuildData` method, on the same class.
It should be reset to 0 only when the index change.



