### PR TITLE
GSSPRT-137: Filter Prospects Without Client

### DIFF
--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -19,6 +19,7 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
     $params = array(
       'sequential' => 1,
       'is_deleted' => 0,
+      'client_id' => ['IS NOT NULL' => 1],
       'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
       'api.ProspectConverted.get' => array('prospect_case_id' => '$value.id'),
       'return' => array_merge($this->getCaseFields(), array('subject', 'contacts', 'contact_id')),
@@ -187,5 +188,15 @@ class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
     }
 
     return $this->fields;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(array $params = []) {
+    return civicrm_api3('Case', 'getcount', [
+      'is_deleted' => 0,
+      'client_id' => ['IS NOT NULL' => 1],
+    ]);
   }
 }


### PR DESCRIPTION
## Overview
This PR solves an issue related to Prospect reports, that occurred when one or more prospects had no contact associated.

## Before
All the prospects without contact were presented in one row:
<img width="1650" alt="Screen Shot 2021-07-26 at 21 08 36" src="https://user-images.githubusercontent.com/74304572/127007001-9591615a-9717-411d-81c9-8c2db414c265.png">
In this screenshot, we can see the prospect with IDs 2790 and 2791 mixed in the same row, with 25 random contacts appearing on the contact column. There are 25  because of the default limit on the API call.

## After
The prospects without contacts are not displayed.
<img width="1605" alt="Screen Shot 2021-07-26 at 20 53 48" src="https://user-images.githubusercontent.com/74304572/127007520-fa580edb-64fe-4a3f-b8e3-d2689d9d04eb.png">

## Technical Details
This chained API call inside the Prospect.get is causing the problem:
```php
'api.Contact.get' => array('id' => '$value.client_id', 'return' => array('id', 'contact_type', 'contact_sub_type', 'display_name')),
```
because `$value.client_id` is null on the Case data.
For solving this, we should filter by Cases having client:
```php
      'client_id' => ['IS NOT NULL' => 1],
```
Also, the `getCount` method was modified, since it should return all the matching results on the same query.
