### PR TITLE
GSSPRT-148: Decrease the rows returned for Prospect report cache

### DIFF
--- a/CRM/PivotData/DataProspect.php
+++ b/CRM/PivotData/DataProspect.php
@@ -6,6 +6,11 @@
 class CRM_PivotData_DataProspect extends CRM_PivotData_DataCase {
 
   /**
+   * @inheritdoc
+   */
+  const ROWS_API_LIMIT = 500;
+
+  /**
    * CRM_PivotData_DataProspect constructor.
    */
   public function __construct() {


### PR DESCRIPTION
## Overview
This PR solves a problem generating the cache for the prospect reports. The process of cache generation was stuck on a percentage less than 100%.

## Before
While running the "Refresh All Pivot Reports", the action get stopped, because of a timeout error in one of the Ajax request performed:
<img width="1586" alt="Screen Shot 2021-09-23 at 16 04 13" src="https://user-images.githubusercontent.com/74304572/134481130-935b5de3-c3b9-4392-8be4-96b7d99614b7.png">

## After
The action finishes without errors:
<img width="1586" alt="Screen Shot 2021-09-23 at 16 24 56" src="https://user-images.githubusercontent.com/74304572/134491016-8797019c-a64e-4616-ab1e-c9b485c0f9e8.png">

## Technical Details
The timeout observed is in one of the requests to the Prospect API (with Js library), for getting a set of results in order to create the report cache.
For solving this, without having to think about query optimization, we can use the constant defined on `CRM_PivotData_AbstractData` class named `ROWS_API_LIMIT`. This indicates the number of results to be queried on every call to CiviCRM API, for each entity. A lower number could speedup the query time, and the result will be the same, since the calls are performed one after the other until there is no more results.
We can override that value for the Prospect entity, in `CRM_PivotData_DataProspect` class, which is the one with performance problems. The same was done before with the [Activity related class](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/blob/master/CRM/PivotData/DataActivity.php#L10). 
Using 500 instead of 1000 probed to solve the problem.
**Note:** The query could be working slowly now since we have recently added [an extra condition](https://github.com/compucorp/uk.co.compucorp.civicrm.pivotreport/commit/9eab4ad5acffff7cfb7501f0ce9764d9efab5d64) to the where clause on Prospects. Nevertheless, in the environments where this fail (which are not production environments) the query was also timing out before this change.
