### PR TITLE
permission fix for CiviCRM 5.71+

### DIFF
--- a/pivotreport.php
+++ b/pivotreport.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'pivotreport.civix.php';
+use CRM_PivotReport_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_config().
@@ -177,11 +178,17 @@ function pivotreport_civicrm_pageRun($page) {
  * @return void
  */
 function pivotreport_civicrm_permission(&$permissions) {
-  $prefix = ts('CiviCRM Reports') . ': '; // name of extension or module
-  $permissions += array(
-    'access CiviCRM pivot table reports' => $prefix . ts('access CiviCRM pivot table reports'),
-    'Admin Pivot Report' => $prefix . ts('Admin Pivot Report'),
-  );
+  $prefix = ts('CiviCRM Reports') . ': ';
+  $permissions += [
+    'access CiviCRM pivot table reports' => [
+      'label' => $prefix . E::ts('access CiviCRM pivot table reports'),
+      'description' => E::ts('access CiviCRM pivot table reports'),
+    ],
+    'Admin Pivot Report' => [
+      'label' => $prefix . E::ts('Admin Pivot Report'),
+      'description' => E::ts('Admin Pivot Report'),
+    ],
+  ];
 }
 
 /**


### PR DESCRIPTION
CiviCRM 5.0+ uses a newer format for declaring permissions.  As of Civi 5.71, the old format is deprecated.  This should close #141.