### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
   <version>2.1.0</version>
   <develStage>Stable</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments/>
   <civix>

--- a/templates/CRM/PivotReport/Page/PivotReportAdmin.tpl
+++ b/templates/CRM/PivotReport/Page/PivotReportAdmin.tpl
@@ -1,6 +1,6 @@
 <div id="pivot-report-admin">
   <div class="rebuild-pivot-report-cache">
-    <input class="build-cache-button" type="button" value="{ts}Refresh All Pivot Reports{/ts}">
+    <input class="build-cache-button" type="button" value="{ts escape='htmlattribute'}Refresh All Pivot Reports{/ts}">
     <div class="in-progress hidden">
       <i class="fa fa-spinner fa-spin"></i>
       <span>{ts}Building report cache. This might take a few minutes.{/ts}</span>

--- a/templates/CRM/PivotReport/Page/ReportConfig.tpl
+++ b/templates/CRM/PivotReport/Page/ReportConfig.tpl
@@ -10,13 +10,13 @@
       </select>
       {if ($canManagePivotReportConfig)}
         <div class="form-item">
-          <input type="button" class="report-config-save-btn btn btn-primary hidden" value="{ts}Save Report{/ts}">
+          <input type="button" class="report-config-save-btn btn btn-primary hidden" value="{ts escape='htmlattribute'}Save Report{/ts}">
         </div>
         <div class="form-item">
-          <input type="button" class="report-config-save-new-btn btn btn-primary" value="{ts}Save As New{/ts}">
+          <input type="button" class="report-config-save-new-btn btn btn-primary" value="{ts escape='htmlattribute'}Save As New{/ts}">
         </div>
         <div class="form-item">
-          <input type="button" class="report-config-delete-btn btn btn-danger hidden" value="{ts}Delete{/ts}">
+          <input type="button" class="report-config-delete-btn btn btn-danger hidden" value="{ts escape='htmlattribute'}Delete{/ts}">
         </div>
       {/if}
     </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.