### PR TITLE
COMCL-1440: Fix handling of large datasets in pivot reports

### DIFF
--- a/CRM/PivotCache/AbstractGroup.php
+++ b/CRM/PivotCache/AbstractGroup.php
@@ -10,7 +10,7 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
   /**
    * Name of cache group.
    *
-   * @var string 
+   * @var string
    */
   protected $name = NULL;
 
@@ -153,6 +153,31 @@ abstract class CRM_PivotCache_AbstractGroup implements CRM_PivotCache_GroupInter
    * @param array $params
    */
   protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
+    if (!empty($params['keyvalue_from'])) {
+      $whereStartDate = CRM_Core_DAO::createSQLFilter(
+        // Remove the unique suffix added to the path.
+        'LEFT(path, LENGTH(path) - 14)',
+        array(
+          '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page, FALSE),
+        ),
+        'String'
+      );
+
+      $queryObject->whereAdd($whereStartDate);
+    }
+
+    if (!empty($params['keyvalue_to'])) {
+      $whereEndDate = CRM_Core_DAO::createSQLFilter(
+        // Remove the unique suffix added to the path.
+        'LEFT(path, LENGTH(path) - 14)',
+        array(
+          '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999, FALSE),
+        ),
+        'String'
+      );
+
+      $queryObject->whereAdd($whereEndDate);
+    }
   }
 
   /**

--- a/CRM/PivotCache/GroupActivity.php
+++ b/CRM/PivotCache/GroupActivity.php
@@ -8,35 +8,4 @@ class CRM_PivotCache_GroupActivity extends CRM_PivotCache_AbstractGroup {
   public function __construct($name = NULL, $source = NULL) {
     parent::__construct('Activity', $source);
   }
-
-  /**
-   * @inheritdoc
-   */
-  protected function customizeQuery(CRM_PivotReport_DAO_PivotReportCache $queryObject, $page, array $params) {
-    if (!empty($params['keyvalue_from'])) {
-      $whereStartDate = CRM_Core_DAO::createSQLFilter(
-        // Remove the unique suffix added to the path.
-        'LEFT(path, LENGTH(path) - 14)',
-        array(
-          '>=' => $this->getPath(substr($params['keyvalue_from'], 0, 10), $page, FALSE),
-        ),
-        'String'
-      );
-
-      $queryObject->whereAdd($whereStartDate);
-    }
-
-    if (!empty($params['keyvalue_to'])) {
-      $whereEndDate = CRM_Core_DAO::createSQLFilter(
-      // Remove the unique suffix added to the path.
-        'LEFT(path, LENGTH(path) - 14)',
-        array(
-          '<=' => $this->getPath(substr($params['keyvalue_to'], 0, 10), 999999, FALSE),
-        ),
-        'String'
-      );
-
-      $queryObject->whereAdd($whereEndDate);
-    }
-  }
 }

--- a/js/PivotReport.PivotTable.js
+++ b/js/PivotReport.PivotTable.js
@@ -336,7 +336,7 @@ CRM.PivotReport.PivotTable = (function($) {
       that.data = that.data.concat(that.processData(result['values'][0].data));
       var nextKeyValue = result['values'][0].nextKeyValue;
       var nextPage = result['values'][0].nextPage;
-      var progressValue = parseInt((that.totalLoaded / totalCount) * 100, 10);
+      var progressValue = Math.min(parseInt((that.totalLoaded / totalCount) * 100, 10), 100);
 
       that.Preloader.setValue(progressValue);
 


### PR DESCRIPTION
## Overview

Fixes an infinite-loop bug in the Pivot Report extension that caused browsers to freeze and crash when loading pivot reports with more than ~10,000 rows. Observed on the Membership report with 53,156 rows, but the same latent bug affected the Contribution, Case, and Prospect reports. The loader bar climbed past 100% sometimes to several thousand percent because the client kept receiving and concatenating duplicate batches until the tab exhausted memory. As part of the fix the shared cursor-filter logic has been hoisted from a single entity into the base class so every pivot entity inherits it by default.

## Technical Details

`CRM_PivotCache_AbstractDataSet::get()` reads cached rows in 10,000-row windows and hands the client a `nextKeyValue` / `nextPage` cursor. That cursor is meant to be applied as a SQL `WHERE` filter by `CRM_PivotCache_AbstractGroup::query()` through its `customizeQuery()` hook. Historically only `CRM_PivotCache_GroupActivity` implemented that hook; `GroupMembership`, `GroupContribution`, `GroupCase`, and `GroupProspect` all inherited an empty base-class version. Their cache queries therefore ran `ORDER BY path ASC` with no cursor filter and returned the same first 10,000 rows on every batch call, regardless of what `keyvalue_from` / `page` the client passed. The client then looped forever: each response reported the same `nextKeyValue` it had just seen, and `this.data.concat(...)` kept appending duplicate rows. The progress bar is calculated as `totalLoaded / pivotCount * 100`, so with `totalLoaded` growing unboundedly against a fixed denominator, the number ran past 100% into the thousands of percent before the browser ran out of RAM.

The filter logic itself is entity-agnostic  it only depends on the universal `data_<index>_<page>_<uniqid>` cache-path shape defined by `AbstractGroup::getPath()`. So instead of copying the override into each of the four affected subclasses, the body has been moved into `AbstractGroup::customizeQuery()` itself. Every entity now inherits correct pagination by default, and the now-redundant override in `GroupActivity` has been removed. Any future entity with a genuinely different cursor shape can still override and either replace or extend the default (`parent::customizeQuery()` first, then add its own `whereAdd()` clauses).

A defensive `Math.min(progressValue, 100)` clamp has also been added in `PivotReport.PivotTable.js` so the progress bar can never visually exceed 100% even if a future regression reintroduces a count-vs-rows mismatch.